### PR TITLE
add instructions on using Homebrew & xhyve

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,11 +22,16 @@ Ubuntu:
     chmod +x minikube )
 #+end_src
 
-MacOS:
+MacOS (manual installation):
 #+begin_src sh
   ( cd ~/.local/bin ;# OR YOUR FAVORITE PERSONAL BIN DIR IN YOUR $PATH
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.10.0/minikube-darwin-amd64 ;
     chmod +x minikube )
+#+end_src
+
+MacOS (Using Homebrew):
+#+begin_src sh
+  brew install minikube
 #+end_src
 
 *** Install a Virtual Machine Driver
@@ -45,6 +50,11 @@ Ubuntu (KVM):
 Ubuntu or MacOS (VirtualBox):
 Head over to https://virtualbox.org/downloads and use their instructions
 
+MacOS ([[https://github.com/mist64/xhyve][xhyve]] - lightweight virtualization on top of Mac OS X's Hyperwisor.framework, similar to KVM):
+#+begin_src sh
+  brew install xhyve docker-machine-driver-xhyve
+#+end_src
+
 ** Install Kubernetes Control Executable
 
 Ubuntu:
@@ -54,11 +64,16 @@ Ubuntu:
     chmod +x kubectl )
 #+end_src
 
-MacOS:
+MacOS (manual installation):
 #+begin_src sh
   ( cd ~/.local/bin ;
     curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.4.0/bin/darwin/amd64/kubectl ;
     chmod +x kubectl )
+#+end_src
+
+MacOS (Using Homebrew):
+#+begin_src sh
+  brew install kubectl
 #+end_src
 
 * Minikube Management
@@ -79,7 +94,7 @@ KVM (Linux):
       --vm-driver=kvm
 #+end_src
 
-VirtualBox (Linux|Mac):
+VirtualBox (Linux|MacOS):
 #+begin_src sh
   minikube start \
       --cpus=1 \
@@ -87,6 +102,16 @@ VirtualBox (Linux|Mac):
       --kubernetes-version="v1.4.0" \
       --memory=1024 \
       --vm-driver=virtualbox
+#+end_src
+
+xhyve (MacOS):
+#+begin_src sh
+  minikube start \
+      --cpus=1 \
+      --disk-size="10g" \
+      --kubernetes-version="v1.4.0" \
+      --memory=1024 \
+      --vm-driver=xhyve
 #+end_src
 
 ** Exercise Kubernetes Control


### PR DESCRIPTION
Many Mac OS users already have Homebrew installed, so it makes sense to use it instead of manual installation.

for Mac OS 10.10 & higher, there is xhyve project that uses built-in virtualization framework that is easier to use than VirtualBox. The same framework is used by Docker on Mac.
